### PR TITLE
fix .vscode config to use prettier correctly

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,4 @@
-{
+{ 
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
   "editor.formatOnSave": true
 }


### PR DESCRIPTION
## Description

Fix the .vscode settings so the default formatter is set to prettier for vscode

## Closes issue(s)

N/A

## How to test / reproduce

## Screenshots

N/A

## Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [x] New feature (non-breaking change that adds functionality)

## Checklist

- [x] I have tested this code

## Other comments
